### PR TITLE
Bump xmscore/xmsgrid/xmsinterp and regenerate CI with xmsconan 2.18.0

### DIFF
--- a/.github/workflows/XmsStamper-CI.yaml
+++ b/.github/workflows/XmsStamper-CI.yaml
@@ -31,7 +31,7 @@ jobs:
     steps:
       # Checkout Sources
       - name: Checkout Source
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       # Setup Python
       - name: Setup Python ${{ matrix.python-version }}
         uses: actions/setup-python@v2
@@ -42,10 +42,15 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install flake8 flake8-docstrings flake8-bugbear flake8-import-order pep8-naming
+          pip install --upgrade "xmsconan>=2.18.0" -i https://public.aquapi.aquaveo.com/aquaveo/dev/+simple
+      # Generate .flake8 so CI lints with the same config developers use locally.
+      # Do not inline the flake8 settings here: that duplicates .flake8.jinja and
+      # the two copies drift apart silently.
+      - name: Generate Build Files
+        run: xmsconan_gen build.toml
       # Flake Code
       - name: Run Flake
-        run: |
-          flake8 --exclude .tox,.git,__pycache__,_package/tests/files/*,pydocs/source/conf.py,build,dist,tests/fixtures/*,*.pyc,*.egg-info,.cache,.eggs --ignore=D200,D212 --max-line-length=120 --docstring-convention google --isolated --import-order-style=appnexus --application-import-names=xms.stamper --application-package-names=xms --count --statistics _package
+        run: flake8 _package
 
   # ----------------------------------------------------------------------------------------------
   # MAC
@@ -94,7 +99,7 @@ jobs:
           clang --version
       # Checkout Sources
       - name: Checkout Source
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       # Setup Python
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v5
@@ -104,8 +109,11 @@ jobs:
       - name: Install Python Dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install conan devpi-client wheel
-          python -m pip install xmsconan>=2.12.2 -i https://public.aquapi.aquaveo.com/aquaveo/dev/+simple
+          # conan is pinned to a patch series on purpose: a minor bump can change
+          # package_id computation and silently detach builds from the binaries
+          # already published to the remote. Bump this deliberately.
+          pip install "conan~=2.31.0" devpi-client wheel
+          python -m pip install --upgrade "xmsconan>=2.18.0" -i https://public.aquapi.aquaveo.com/aquaveo/dev/+simple
       # Setup Conan
       - name: Setup Conan
         run: xmsconan_conan_setup --remote-url ${{ env.CONAN_REMOTE_URL }} --login --remove-conancenter
@@ -234,12 +242,15 @@ jobs:
     steps:
       # Checkout Sources
       - name: Checkout Source
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       # Install Python Dependencies
       - name: Install Python Dependencies
         run: |
-          pip install conan devpi-client wheel
-          pip install xmsconan>=2.12.2 -i https://public.aquapi.aquaveo.com/aquaveo/dev/+simple
+          # conan is pinned to a patch series on purpose: a minor bump can change
+          # package_id computation and silently detach builds from the binaries
+          # already published to the remote. Bump this deliberately.
+          pip install "conan~=2.31.0" devpi-client wheel
+          pip install --upgrade "xmsconan>=2.18.0" -i https://public.aquapi.aquaveo.com/aquaveo/dev/+simple
       # Setup Conan
       - name: Setup Conan
         run: xmsconan_conan_setup --remote-url ${{ env.CONAN_REMOTE_URL }} --login
@@ -368,7 +379,7 @@ jobs:
     steps:
       # Checkout Sources
       - name: Checkout Source
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       # Setup Python
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v5
@@ -383,8 +394,11 @@ jobs:
       - name: Install Python Dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install conan devpi-client wheel
-          python -m pip install xmsconan>=2.12.2 -i https://public.aquapi.aquaveo.com/aquaveo/dev/+simple
+          # conan is pinned to a patch series on purpose: a minor bump can change
+          # package_id computation and silently detach builds from the binaries
+          # already published to the remote. Bump this deliberately.
+          pip install "conan~=2.31.0" devpi-client wheel
+          python -m pip install --upgrade "xmsconan>=2.18.0" -i https://public.aquapi.aquaveo.com/aquaveo/dev/+simple
       # Setup Visual Studio
       - name: Setup Visual Studio
         uses: microsoft/setup-msbuild@v2

--- a/build.toml
+++ b/build.toml
@@ -4,9 +4,9 @@ ci_type = "github"
 extra_export_sources = ["test_files"]
 
 xms_dependencies = [
-    { name = "xmscore", version = "7.0.8" },
-    { name = "xmsgrid", version = "9.0.9" },
-    { name = "xmsinterp", version = "7.0.8" },
+    { name = "xmscore", version = "7.0.12" },
+    { name = "xmsgrid", version = "9.0.11" },
+    { name = "xmsinterp", version = "7.0.10" },
 ]
 
 python_namespaced_dir = "stamper"


### PR DESCRIPTION
Sixth library onto the VS2019 bridge. **Unlike the previous five, the CI diff here is not pins-only** — this repo was last regenerated from xmsconan **2.12.2**, so it carries six minor versions of accumulated template changes. Everything is enumerated below; please skim the conan-pin item in particular.

## 1. Dependency bumps — required

| dependency | from | to |
|---|---|---|
| xmscore | 7.0.8 | **7.0.12** |
| xmsgrid | 9.0.9 | **9.0.11** |
| xmsinterp | 7.0.8 | **7.0.10** |

`xms_dependencies` pins **exact** versions and none of the old ones was ever built for msvc 192. Only the new versions exist on `aquaveo-vs2019`, so left as-is the VS2019 build fails at graph resolution. This repo trailed furthest behind of the seven — several releases rather than one.

Each target version is published on both remotes at a single matching recipe revision (`xmscore c58afa49…`, `xmsgrid 66ac6991…`, `xmsinterp 7fb0a48d…`), and each of those releases was itself only a dependency-and-CI bump with no C++ source change.

## 2. xmsconan `>=2.12.2` → `>=2.18.0`

CI must generate the recipe with the same xmsconan the manual VS2019 track uses. `XmsConan2File.export()` copies `xms_conan2_file.py` into the export folder, so its contents feed the **recipe revision hash**, and 2.18.0 changes that file by 192 lines (the msvc 192 fork).

## 3. ⚠️ conan is now pinned to `~=2.31.0` — the one item with behavioral weight

This CI previously ran a bare `pip install conan`, so its builds used **whatever conan was current on the day**. A conan minor bump can change `package_id` computation and silently detach builds from binaries already published to the remote.

Pinning is correct and matches every other repo in the suite, but be aware: package_ids computed under the pinned client may differ from those computed under whatever floated before. This is the only change in this PR that could move anything on the msvc 194 side.

## 4. `actions/checkout` v2 → v4

v2 is deprecated — GitHub force-runs its Node 20 actions on Node 24 and warns.

## 5. Flake job generates its own config

The inline flake8 argument list is replaced by `xmsconan_gen build.toml` then `flake8 _package`, so CI lints with the same `.flake8` developers get locally rather than a duplicated argument list that drifts silently.

Verified `gen` produces `.flake8` and `pytest.ini` at runtime, so the job is self-sufficient. Note that unlike xmscore and xmsgrid, this repo does **not** track those two generated files — left as-is to keep this change scoped, but worth aligning separately if you want consistency across the suite.

## Verified

- Regenerated recipe: `["xmscore/7.0.12", "xmsgrid/9.0.11", "xmsinterp/7.0.10"]`, `testing_framework = "cxxtest"` (relevant because `gtest/1.17.0` has no msvc 192 build).
- Every non-pin CI change is enumerated above — nothing unaccounted for.

🤖 Generated with [Claude Code](https://claude.com/claude-code)